### PR TITLE
Dont use ansible_default_ipv6

### DIFF
--- a/roles/pihole/defaults/main.yaml
+++ b/roles/pihole/defaults/main.yaml
@@ -1,0 +1,1 @@
+pihole_bind_interface: eth0

--- a/roles/pihole/tasks/main.yaml
+++ b/roles/pihole/tasks/main.yaml
@@ -20,7 +20,7 @@
 - name: Get IPv6 link local address
   set_fact:
     ipv6: "{{ item.address }}"
-  loop: "{{ vars['ansible_' + ansible_default_ipv6.interface].ipv6 }}"
+  loop: "{{ vars['ansible_' + pihole_bind_interface].ipv6 }}"
   loop_control:
     label: "{{ item.address }}"
   when: "'link' in item.scope"


### PR DESCRIPTION
ansible_default_ipv6 returns the loopback interface as per
this bug: https://github.com/ansible/ansible/issues/16977

This change allows us to speficy a default interface while
still allowing for easy customization by the user.