### PR TITLE
Add openssh_keypair module requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The repository contains four Ansible Playbooks. Each one is described here short
 
 ## Base Setup
 - An [Ansible](https://www.ansible.com/) controller machine with Ansible [installed](https://docs.ansible.com/ansible/latest/installation_guide/index.html) (version 2.10 or later)
+- The [openssh_keypair](https://docs.ansible.com/ansible/latest/collections/community/crypto/openssh_keypair_module.html) Ansible module installed.
 - One or more Raspberry Pi's with [Raspberry Pi OS Lite](https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit)
 - Headless setup (configuration before first boot):
   - Enable [SSH](https://www.raspberrypi.org/documentation/remote-access/ssh/README.md) `"3. Enable SSH on a headless Raspberry Pi..."`


### PR DESCRIPTION
The openssh_keypair module is not installed by default on MacOS (via HomeBrew).
This adds that as a requirement via the README's Base Setup section.