### PR TITLE
Use ansible_default_ipv4.interface if ansible_default_ipv6.interface is undefined

### DIFF
--- a/roles/keepalived/templates/keepalived.j2
+++ b/roles/keepalived/templates/keepalived.j2
@@ -38,7 +38,7 @@ vrrp_instance PIHOLE-IPv4 {
 }
 
 vrrp_instance PIHOLE-IPv6 {
-    interface {{ ansible_default_ipv6.interface }}
+    interface {{ ansible_default_ipv6.interface | default(ansible_default_ipv4.interface) }}
     virtual_router_id 1
     priority {{ priority }}
     advert_int 1

--- a/roles/pihole/tasks/main.yaml
+++ b/roles/pihole/tasks/main.yaml
@@ -20,7 +20,7 @@
 - name: Get IPv6 link local address
   set_fact:
     ipv6: "{{ item.address }}"
-  loop: "{{ vars['ansible_' + ansible_default_ipv6.interface].ipv6 }}"
+  loop: "{{ vars['ansible_' + ansible_default_ipv6.interface | default(ansible_default_ipv4.interface)].ipv6 }}"
   loop_control:
     label: "{{ item.address }}"
   when: "'link' in item.scope"


### PR DESCRIPTION
If `ansible_default_ipv6.interface` is undefined, default to `ansible_default_ipv4.interface`.
Normally IPv4 and IPv6 will run on the same interface, so this should not cause any trouble.
This works around the issue when e.g. IPv6 is disabled on the router and Ansible can't determine the `ansible_default_ipv6` facts which leaves them undefined.

Fixes #5 