### PR TITLE
Sync gravity.db by dumping and restoring

### DIFF
--- a/roles/sync/tasks/main.yaml
+++ b/roles/sync/tasks/main.yaml
@@ -1,3 +1,9 @@
+- name: Install sqlite3
+  apt:
+    force_apt_get: yes
+    name: sqlite3
+  become: yes
+
 - name: Generate ssh keypair
   community.crypto.openssh_keypair:
     comment: pihole-sync-{{ inventory_hostname }}

--- a/roles/sync/templates/pihole_sync.j2
+++ b/roles/sync/templates/pihole_sync.j2
@@ -6,12 +6,18 @@ target="{{ ansible_user }}@{{ sync_target }}"
 sync_dir="{{ ansible_user_dir }}/{{ sync_dir.path }}"
 pihole_dir="{{ ansible_user_dir }}/pihole"
 
+if [[ $(ip a | grep {{ sync_target }}) ]]; then
+  nice -n 19 sqlite3 $pihole_dir/pihole/gravity.db ".backup $sync_dir/gravity.dump"
+fi
+
 if [[ ! $(ip a | grep {{ sync_target }}) ]]; then
-  RSYNC_GRAVITY=$(rsync -a --info=name -e "ssh $key $host_key_check" $target:$pihole_dir/pihole/gravity.db $sync_dir)
+  sleep 60
+
+  RSYNC_GRAVITY=$(rsync -a --info=name -e "ssh $key $host_key_check" $target:$sync_dir/gravity.dump $sync_dir)
   if [ $? -eq 0 ]; then
     if [ -n "$RSYNC_GRAVITY" ]; then
       docker stop pihole
-      sudo cp --preserve=timestamps $sync_dir/gravity.db $pihole_dir/pihole
+      sudo sqlite3 $pihole_dir/pihole/gravity.db ".restore $sync_dir/gravity.dump"
       docker start pihole
     fi
   fi


### PR DESCRIPTION
Sync the DB by dumping and restoring with sqlite3.
- On primary: Make backup of the DB (process has lowest priority for minimum impact on dns performance)
- On secondaries: Wait 60 seconds until DB is dumped on primary. Then rsync the dump file if changes are detected, stop the pihole container, restore the DB and start the pihole container again.