### PR TITLE
Set ServerIPs depending on HA or Single mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ These roles are included:
   - Disable password authentication
 - [`docker`](roles/docker/tasks/main.yaml): Install and configure Docker
 - [`pihole`](roles/pihole/tasks/main.yaml): Start/Update Pi-hole container
-  - Pi-hole container settings are configured in [`inventory.yaml`](inventory.yaml#L17-L24)
+  - Pi-hole container settings are configured in [`inventory.yaml`](inventory.yaml#L17-L25)
+  - The [`pihole_ha_mode`](inventory.yaml#L25) option is used to switch between HA or Single mode to determine the IPv4/IPv6 addresses for the Pi-hole services (bind IPs for Web/DNS, pi.hole DNS record) and is enabled by default.  
+    ⚠️ Disable this if you don't intend to deploy a HA setup with keepalived.
 
 ## `update-pihole.yaml`
 This playbook is for subsequent runs after the `bootstrap-pihole.yaml` playbook was run at least once.  
@@ -59,7 +61,7 @@ The priority of each Pi-hole can be configured in [`inventory.yaml`](inventory.y
       ansible_host: 192.168.178.45
       priority: 101
 ```
-The desired VIPs (Virtual IPs) for IPv4 and IPv6 can be configured in [`inventory.yaml`](inventory.yaml#L25-L26):
+The desired VIPs (Virtual IPs) for IPv4 and IPv6 can be configured in [`inventory.yaml`](inventory.yaml#L26-L27):
 ```yaml
     pihole_vip_ipv4: "192.168.178.10/24"
     pihole_vip_ipv6: "fd00::10/64"
@@ -76,14 +78,15 @@ What gets synced:
 - `custom.list` (Local DNS Records)
 - `05-pihole-custom-cname.conf` (Local CNAME Records)
 
-If you enabled HA (high availability) with the `keepalived.yaml` playbook, the primary instance will be the one currently occupying the Virtual IP address (evaluated at each cronjob run).  
-Otherwise you can set the [`sync_target`](inventory.yaml#L27) variable to the IP address of your primary Pi-hole instance.
+#### Default: Pull from VIP
+If you enabled HA (high availability) with the `keepalived.yaml` playbook, the primary instance will be the one currently occupying the Virtual IP address (evaluated at each cronjob run).
 
-Default: Pull from VIP
 ```yaml
 sync_target: "{{ pihole_vip_ipv4.split('/')[0] }}"
 ```
-Alternative: Pull from primary instance (assuming your primary is `pihole-1`, otherwise adapt)
+
+#### Alternative: Pull from primary instance
+You can set the [`sync_target`](inventory.yaml#L28) variable to the IP address of your primary Pi-hole instance (in my example `pihole-1`, otherwise adapt).
 ```yaml
 sync_target: "{{ hostvars['pihole-1'].ansible_host }}"
 ```

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -22,6 +22,7 @@ all:
     pihole_rev_server_domain: "fritz.box"
     pihole_rev_server_target: "192.168.178.1"
     pihole_rev_server_cidr: "192.168.178.0/24"
+    pihole_ha_mode: yes
     pihole_vip_ipv4: "192.168.178.10/24"
     pihole_vip_ipv6: "fd00::10/64"
     sync_target: "{{ pihole_vip_ipv4.split('/')[0] }}"

--- a/roles/pihole/tasks/main.yaml
+++ b/roles/pihole/tasks/main.yaml
@@ -27,6 +27,20 @@
     label: "{{ item.address }}"
   when: "'link' in item.scope"
 
+- name: Set ServerIP addresses (HA mode)
+  set_fact:
+    server_ip: "{{ pihole_vip_ipv4.split('/')[0] }}"
+    server_ip_v6: "{{ pihole_vip_ipv6.split('/')[0] }}"
+    execution_mode: "HA setup with keepalived"
+  when: pihole_ha_mode
+
+- name: Set ServerIP addresses (single mode)
+  set_fact:
+    server_ip: "{{ ansible_host }}"
+    server_ip_v6: "{{ ipv6 }}"
+    execution_mode: "single node setup"
+  when: not pihole_ha_mode
+
 - name: Start/Update pihole container
   docker_container:
     name: pihole
@@ -35,8 +49,8 @@
     restart_policy: unless-stopped
     env:
       TZ: "{{ timezone }}"
-      ServerIP: "0.0.0.0"
-      ServerIPv6: "::"
+      ServerIP: "{{ server_ip }}"
+      ServerIPv6: "{{ server_ip_v6 }}"
       WEBPASSWORD: "{{ pihole_webpassword }}"
       PIHOLE_DNS_: "{{ pihole_dns }}"
       DNSMASQ_LISTENING: "local"
@@ -70,13 +84,9 @@
     images_filters:
       dangling: false
 
-- name: ATTENTION!!!
+- name: INFORMATION
   debug:
     msg:
-      - "Make sure to point your DNS server settings to this Pi-hole:"
-      - "DNSv4: {{ ansible_host }}"
-      - "DNSv6: {{ ipv6 }}"
-      - ""
-      - "In the HA setup with keepalived, these are your settings:"
-      - "DNSv4: {{ pihole_vip_ipv4.split('/')[0] }}"
-      - "DNSv6: {{ pihole_vip_ipv6.split('/')[0] }}"
+      - "In the {{ execution_mode }} make sure to point your DNS server settings here:"
+      - "DNSv4: {{ server_ip }}"
+      - "DNSv6: {{ server_ip_v6 }}"


### PR DESCRIPTION
Since the latest pihole update, the ServerIP/ServerIPv6 addresses are used to serve the pi.hole DNS record.
Also they are (somewhat) used as bind addresses of the web/dns services.
- In HA mode: Use the VIPs configured in the inventory
- In single mode: Use the host IPs

Also simplified the information output.